### PR TITLE
Enable soft deletes

### DIFF
--- a/backend/question/src/models/Question.ts
+++ b/backend/question/src/models/Question.ts
@@ -11,6 +11,7 @@ export type TQuestion = {
   description: string;
   category: [string];
   complexity: string;
+  deleted: boolean;
 };
 
 // Document provides an id field
@@ -32,6 +33,10 @@ const questionSchema: Schema = new Schema(
     },
     complexity: {
       type: String,
+      required: true,
+    },
+    deleted: {
+      type: Boolean,
       required: true,
     },
   },

--- a/backend/question/src/tests/app.spec.ts
+++ b/backend/question/src/tests/app.spec.ts
@@ -250,7 +250,6 @@ describe("Test Get All", () => {
   test("POST /api/all - should retrieve all questions", async () => {
     const res = await request.post("/api/all").send();
     const sampleQuestion = res.body.questions[0];
-    console.log(res.body);
     expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body.questions)).toBe(true);
     expect(res.body.questions.length).toBe(1);

--- a/backend/question/src/tests/app.spec.ts
+++ b/backend/question/src/tests/app.spec.ts
@@ -250,6 +250,7 @@ describe("Test Get All", () => {
   test("POST /api/all - should retrieve all questions", async () => {
     const res = await request.post("/api/all").send();
     const sampleQuestion = res.body.questions[0];
+    console.log(res.body);
     expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body.questions)).toBe(true);
     expect(res.body.questions.length).toBe(1);
@@ -407,7 +408,7 @@ describe("Test Update", () => {
       .post(`/api/${questionId}/update`)
       .send(updateQuestion);
     expect(res.statusCode).toBe(404);
-    expect(res.body).toBe("Document not found");
+    expect(res.body.message).toBe("Question not found");
   });
 
   // Non-existent id
@@ -423,7 +424,7 @@ describe("Test Update", () => {
       .post(`/api/${questionId}/update`)
       .send(updateQuestion);
     expect(res.statusCode).toBe(404);
-    expect(res.body).toBe("Document not found");
+    expect(res.body.message).toBe("Question not found");
   });
 
   // Duplicate question


### PR DESCRIPTION
This feature is to ensure that the history of the question can be kept even after deletion.

- Adds `deleted` field to the database
- New questions have `deleted` set to `false`
- Deleted question now sets the question's `deleted` field to `true` instead of completely removing it from the database
- `GET` requests will only return the questions with `deleted` field set as `false`, else they will return `Question not found`.

This PR closes #81 