### PR TITLE
Change collaboration/question service endpoints

### DIFF
--- a/backend/collaboration/src/models/Session.ts
+++ b/backend/collaboration/src/models/Session.ts
@@ -7,11 +7,8 @@ import mongoose, { Document, Schema } from "mongoose";
 export type TSession = {
   collabid: string;
   users: [string];
-  difficulty: string;
   language: [string];
-  topic: string;
-  question_title: string;
-  question_description: string;
+  question_id: number;
   code: string;
 };
 
@@ -28,24 +25,12 @@ const sessionSchema: Schema = new Schema(
       type: [String],
       required: true,
     },
-    difficulty: {
-      type: String,
-      required: true,
-    },
     language: {
       type: [String],
       required: true,
     },
-    topic: {
-      type: String,
-      required: true,
-    },
-    question_title: {
-      type: String,
-      required: true,
-    },
-    question_description: {
-      type: String,
+    question_id: {
+      type: Number,
       required: true,
     },
     code: {

--- a/backend/collaboration/src/routes/collaborationRoutes.ts
+++ b/backend/collaboration/src/routes/collaborationRoutes.ts
@@ -27,15 +27,7 @@ router.post(
       return res.status(400).json({ errors: errors.array() });
     }
     try {
-      const {
-        collabid,
-        users,
-        difficulty,
-        language,
-        topic,
-        question_title,
-        question_description,
-      } = req.body;
+      const { collabid, users, language, question_id } = req.body;
 
       const existingSession = await Session.findOne({ collabid: collabid });
       if (existingSession) {
@@ -47,11 +39,8 @@ router.post(
       const session = {
         collabid,
         users,
-        difficulty,
         language,
-        topic,
-        question_title,
-        question_description,
+        question_id,
         code: "",
       };
 
@@ -111,24 +100,6 @@ router.post(
 
     const updateSession: Partial<TSession> = {};
 
-    // if (req.body.users) {
-    //   updateSession.users = req.body.users;
-    // }
-    // if (req.body.difficulty) {
-    //   updateSession.difficulty = req.body.difficulty;
-    // }
-    // if (req.body.language) {
-    //   updateSession.language = req.body.language;
-    // }
-    // if (req.body.topic) {
-    //   updateSession.topic = req.body.topic;
-    // }
-    // if (req.body.question_title) {
-    //   updateSession.question_title = req.body.question_title;
-    // }
-    // if (req.body.question_description) {
-    //   updateSession.question_description = req.body.question_description;
-    // }
     updateSession.code = req.body.code;
 
     try {

--- a/backend/collaboration/src/routes/validators.ts
+++ b/backend/collaboration/src/routes/validators.ts
@@ -2,10 +2,7 @@ import { check } from "express-validator";
 
 export const createSessionValidators = [
   check("collabid").isString().isLength({ min: 1 }),
-  check("difficulty").isString().isLength({ min: 1 }),
-  check("topic").isString().isLength({ min: 1 }),
-  check("question_title").isString().isLength({ min: 1 }),
-  check("question_description").isString().isLength({ min: 1 }),
+  check("question_id").isInt(),
   //custom validation for users
   check("users").custom((users) => {
     if (!Array.isArray(users) || users.length !== 2) {

--- a/backend/question/docs/question.plantuml
+++ b/backend/question/docs/question.plantuml
@@ -27,6 +27,7 @@ interface IQuestionServiceAPI {
   + GET /{id}
   + POST /{id}/update [updateQuestion: EditQuestion]
   + POST /{id}/delete
+  + POST /count-question [complexity: string[], category: string[]]
   + POST /pick-question [complexity: string[], category: string[]]
 }
 
@@ -37,6 +38,7 @@ note right of IQuestionServiceAPI
   - GET /{id}: Retrieve a specific question by ID
   - POST /{id}/update: Update a specific question by ID
   - POST /{id}/delete: Delete a specific question by ID
+  - POST /count-question: Count non-deleted questions given a list of complexities and categories
   - POST /pick-question: Pick a random question given a list of complexities and categories
 end note
 

--- a/backend/question/docs/question.yaml
+++ b/backend/question/docs/question.yaml
@@ -184,6 +184,44 @@ paths:
           description: Question not found
         "500":
           description: Internal server error
+  /count-question:
+    post:
+      summary: Count the number of questions given a list of complexities and categories
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                complexity:
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                  description: Filter by complexities
+                  example: ["Easy"]
+                category:
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                  description: Filter by categories
+                  example: ["Hash Table"]
+
+      responses:
+        "200":
+          description: Questions count
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    example: 1
+
+        "500":
+          description: Internal server error
   /pick-question:
     post:
       summary: Pick a random question given a list of complexities and categories
@@ -244,6 +282,9 @@ components:
         complexity:
           type: string
           example: "Easy"
+        deleted:
+          type: boolean
+          example: false
 
     QuestionCreate:
       type: object

--- a/backend/question/src/routes/questionRoutes.ts
+++ b/backend/question/src/routes/questionRoutes.ts
@@ -132,7 +132,7 @@ router.get("/:id", [...idValidators], async (req: Request, res: Response) => {
 
 // Retrieve the number of questions by complexity and category
 router.post(
-  "/check-question",
+  "/count-question",
   [...pickQuestionValidators],
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
@@ -148,7 +148,7 @@ router.post(
     try {
       const questionCount = await Question.countDocuments(query).exec();
 
-      return res.json(questionCount);
+      return res.json({ count: questionCount });
     } catch (error) {
       return res.status(500).send("Internal server error");
     }

--- a/backend/question/src/routes/questionRoutes.ts
+++ b/backend/question/src/routes/questionRoutes.ts
@@ -118,13 +118,11 @@ router.get("/:id", [...idValidators], async (req: Request, res: Response) => {
         deleted: 1,
       }
     ).exec();
-    if (!question || question.deleted) {
+    if (!question) {
       return res.status(404).json({ message: "Question not found" });
     }
 
-    const { deleted, ...responseQuestion } = question.toObject();
-
-    return res.json(responseQuestion);
+    return res.json(question);
   } catch (error) {
     return res.status(500).send("Internal server error");
   }

--- a/backend/question/src/routes/questionRoutes.ts
+++ b/backend/question/src/routes/questionRoutes.ts
@@ -130,6 +130,31 @@ router.get("/:id", [...idValidators], async (req: Request, res: Response) => {
   }
 });
 
+// Retrieve the number of questions by complexity and category
+router.post(
+  "/check-question",
+  [...pickQuestionValidators],
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { complexity, category } = req.body;
+
+    const query: any = { deleted: false };
+    if (complexity) query.complexity = { $in: complexity };
+    if (category) query.category = { $in: category };
+
+    try {
+      const questionCount = await Question.countDocuments(query).exec();
+
+      return res.json(questionCount);
+    } catch (error) {
+      return res.status(500).send("Internal server error");
+    }
+  }
+);
+
 // Retrieve a random question by complexity and category
 router.post(
   "/pick-question",
@@ -146,7 +171,7 @@ router.post(
     if (category) query.category = { $in: category };
 
     try {
-      const randomQuestion = await Question.aggregate([
+      let randomQuestion = await Question.aggregate([
         { $match: query }, // Filter by complexity and category
         { $sample: { size: 1 } }, // Randomly select one document
         {
@@ -156,9 +181,28 @@ router.post(
             description: 1,
             complexity: 1,
             category: 1,
+            deleted: 1,
           },
         },
       ]).exec();
+
+      if (!randomQuestion.length) {
+        query.deleted = true; // Adjust the query to allow deleted questions
+        randomQuestion = await Question.aggregate([
+          { $match: query }, // Filter by complexity, category, and deleted
+          { $sample: { size: 1 } }, // Randomly select one document
+          {
+            $project: {
+              questionid: 1,
+              title: 1,
+              description: 1,
+              complexity: 1,
+              category: 1,
+              deleted: 1,
+            },
+          },
+        ]).exec();
+      }
 
       if (!randomQuestion.length) {
         return res.status(404).json({ message: "No questions found" });

--- a/backend/question/src/tests/app.spec.ts
+++ b/backend/question/src/tests/app.spec.ts
@@ -716,8 +716,9 @@ describe("Test Delete", () => {
     const res = await request.post(`/api/${questionId}/delete`).send();
     expect(res.statusCode).toBe(200);
     const deleteRes = await request.get(`/api/${questionId}`).send();
-    expect(deleteRes.statusCode).toBe(404);
-    expect(deleteRes.body.message).toBe("Question not found");
+    expect(deleteRes.statusCode).toBe(200);
+    const question = deleteRes.body;
+    expect(question.deleted).toBe(true);
   });
 
   // Negative id

--- a/backend/question/src/tests/app.spec.ts
+++ b/backend/question/src/tests/app.spec.ts
@@ -365,6 +365,37 @@ describe("Test Get All", () => {
   });
 });
 
+// Test /api/count-question
+describe("Test count question", () => {
+  // Valid count question
+  test("POST - count question", async () => {
+    const countQuestionFilter = {
+      complexity: ["Hard"],
+      category: ["Dynamic Programming"],
+    };
+    const res = await request
+      .post(`/api/count-question`)
+      .send(countQuestionFilter);
+    const sampleCount = res.body.count;
+    expect(res.statusCode).toBe(200);
+    expect(sampleCount).toBe(1);
+  });
+
+  // No question exists
+  test("POST - count question - none", async () => {
+    const countQuestionFilter = {
+      complexity: ["Medium"],
+      category: ["Dynamic Programming"],
+    };
+    const res = await request
+      .post(`/api/count-question`)
+      .send(countQuestionFilter);
+    const sampleCount = res.body.count;
+    expect(res.statusCode).toBe(200);
+    expect(sampleCount).toBe(0);
+  });
+});
+
 // Test /api/pick-question
 describe("Test pick question", () => {
   // Valid pick question
@@ -473,6 +504,30 @@ describe("Test pick question", () => {
     expect(res.body.errors[0].msg).toBe(
       "Category must contain only non-empty strings"
     );
+  });
+
+  // Valid pick question - deleted question
+  test("POST - pick question - deleted question", async () => {
+    const pickQuestionFilter = {
+      complexity: ["Hard"],
+      category: ["Dynamic Programming"],
+    };
+    const questionId = 1091; // We start with id 1091
+
+    await request.post(`/api/${questionId}/delete`);
+    const res = await request
+      .post(`/api/pick-question`)
+      .send(pickQuestionFilter);
+    const sampleQuestion = res.body;
+    expect(res.statusCode).toBe(200);
+    expect(sampleQuestion).toHaveProperty("title", "Another Question");
+    expect(sampleQuestion).toHaveProperty(
+      "description",
+      "This is another sample question"
+    );
+    expect(sampleQuestion).toHaveProperty("category", ["Dynamic Programming"]);
+    expect(sampleQuestion).toHaveProperty("complexity", "Hard");
+    expect(sampleQuestion).toHaveProperty("deleted", true);
   });
 });
 

--- a/backend/question/src/tests/app.spec.ts
+++ b/backend/question/src/tests/app.spec.ts
@@ -529,6 +529,28 @@ describe("Test pick question", () => {
     expect(sampleQuestion).toHaveProperty("complexity", "Hard");
     expect(sampleQuestion).toHaveProperty("deleted", true);
   });
+
+  // Valid pick question - deleted and non-deleted questions exist
+  test("POST - pick question - deleted question", async () => {
+    const pickQuestionFilter = {
+      complexity: ["Hard", "Easy"],
+      category: ["Dynamic Programming", "General"],
+    };
+
+    const res = await request
+      .post(`/api/pick-question`)
+      .send(pickQuestionFilter);
+    const sampleQuestion = res.body;
+    expect(res.statusCode).toBe(200);
+    expect(sampleQuestion).toHaveProperty("title", "Sample Question");
+    expect(sampleQuestion).toHaveProperty(
+      "description",
+      "This is a sample question"
+    );
+    expect(sampleQuestion).toHaveProperty("category", ["General"]);
+    expect(sampleQuestion).toHaveProperty("complexity", "Easy");
+    expect(sampleQuestion).toHaveProperty("deleted", false);
+  });
 });
 
 // Test /api/{id}

--- a/frontend/src/app/(auth)/leetcode-dashboard/components/LeetcodeDashboardTable.tsx
+++ b/frontend/src/app/(auth)/leetcode-dashboard/components/LeetcodeDashboardTable.tsx
@@ -284,6 +284,7 @@ export function LeetcodeDashboardTable({
   ];
 
   useEffect(() => {
+    setIsLoading(true);
     getLeetcodeDashboardData(
       pagination.pageIndex + 1,
       pagination.pageSize,


### PR DESCRIPTION
#127 [Question Service: /pick-question deprioritises deleted question]
- `/pick-question` now checks for non-deleted questions first, if none exists it will then return a random deleted question

#126 [Collaboration Service: Change fields]
- Collaboration service database document now contains `collabid`, `users`, `language`, `question_id`, `code`

#125 [Question Service: Enable the querying of deleted + non-deleted questions]
- Enable the querying of deleted questions through `{id}` to allow for history to get deleted questions

#114 [Add spinner before response]
- Add spinner while `/all` is awaiting response

Others:
- Update documentation for question service
- Update test cases for question service